### PR TITLE
Fix Maven configuration so that the code builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,8 @@
   <url>http://maven.apache.org</url>
 
   <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -24,31 +26,29 @@
     <dependency>
     	<groupId>com.nedap.healthcare.archie</groupId>
   		<artifactId>archie-all</artifactId>
-   	 	<version>0.6.1</version>
-	</dependency>
-	<dependency>
-  <groupId>org.openehr.java-libs</groupId>
-  <artifactId>openehr-aom</artifactId>
-  <version>1.0.71</version>
-</dependency>
-	<dependency>
-  <groupId>org.openehr.java-libs</groupId>
-  <artifactId>openehr-rm-core</artifactId>
-  <version>1.0.71</version>
-</dependency>
-<dependency>
-  <groupId>org.openehr.java-libs</groupId>
-  <artifactId>adl-serializer</artifactId>
-  <version>1.0.71</version>
-</dependency>
-<dependency>
-  <groupId>org.openehr.java-libs</groupId>
-  <artifactId>mini-termserv</artifactId>
-  <version>1.0.71</version>
-</dependency>
-
+   	 	<version>1.0.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openehr.java-libs</groupId>
+      <artifactId>openehr-aom</artifactId>
+      <version>1.0.71</version>
+    </dependency>
+      <dependency>
+      <groupId>org.openehr.java-libs</groupId>
+      <artifactId>openehr-rm-core</artifactId>
+      <version>1.0.71</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openehr.java-libs</groupId>
+      <artifactId>adl-serializer</artifactId>
+      <version>1.0.71</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openehr.java-libs</groupId>
+      <artifactId>mini-termserv</artifactId>
+      <version>1.0.71</version>
+    </dependency>
 
   </dependencies>
-  
-  
+
 </project>

--- a/src/main/java/es/veratech/adl2converter/Adl2import.java
+++ b/src/main/java/es/veratech/adl2converter/Adl2import.java
@@ -49,6 +49,7 @@ import org.openehr.terminology.SimpleTerminologyService;
 import org.openehr.referencemodels.BuiltinReferenceModels;
 
 import com.nedap.archie.ArchieLanguageConfiguration;
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.ArchetypeSlot;
@@ -96,7 +97,13 @@ public class Adl2import
     	ArchieRMInfoLookup lookup = ArchieRMInfoLookup.getInstance();
         //String path="c:/temp/arch/openEHR-EHR-EVALUATION.mixed_aom_node_types.v1.0.0.adls";
     	String path="c:/temp/arch/openehr-TEST_PKG-WHOLE.primitive_types.v1.0.0.adls";
-    	Archetype arch = adl2import.parseArch(new File(path));
+    	Archetype arch;
+    	try {
+    		arch = adl2import.parseArch(new File(path));
+    	} catch (ADLParseException e) {
+    		e.printStackTrace();
+    		return;
+    	}
     	adl2import.setArch2(arch);
     	ArchieLanguageConfiguration.setDefaultMeaningAndDescriptionLanguage("en");
     	org.openehr.am.archetype.Archetype arch14;
@@ -614,7 +621,7 @@ public class Adl2import
 
 
 
-	public Archetype parseArch(File adlFile){
+	public Archetype parseArch(File adlFile) throws ADLParseException{
     	ADLParser parser = new ADLParser();
     	try {
 			Archetype archetype = parser.parse(FileUtils.readFileToString(adlFile,"UTF-8"));


### PR DESCRIPTION
The current Maven configuration file has issues which prevent the project from being built.

This PR changes the Java version to 1.8, updates to a newer version of _archie_, and adds a mandatory `try`-`catch` block, ensuring the project gets successfully built.